### PR TITLE
feat(authentication): add twitter as an authentication option for users

### DIFF
--- a/src/app/authentication/containers/login/login.component.html
+++ b/src/app/authentication/containers/login/login.component.html
@@ -19,6 +19,10 @@
     Google
   </ion-button>
 
+  <ion-button (click)="twitterLogin()" [disabled]="!hasAgreed">
+    Twitter
+  </ion-button>
+
   <p *ngIf="loading$ | async">
     Authenticating ...
   </p>

--- a/src/app/authentication/containers/login/login.component.ts
+++ b/src/app/authentication/containers/login/login.component.ts
@@ -81,4 +81,12 @@ export class LoginComponent implements OnInit, OnDestroy {
       this.routerFacade.navigate(navOptions);
     });
   }
+
+  twitterLogin() {
+    this.authFacade.twitterLogin();
+
+    this.loginRedirect$.pipe(take(1)).subscribe(navOptions => {
+      this.routerFacade.navigate(navOptions);
+    });
+  }
 }

--- a/src/app/authentication/services/auth.service.ts
+++ b/src/app/authentication/services/auth.service.ts
@@ -12,6 +12,7 @@ import { User } from '@models/user';
 export class AuthService {
   private googleProvider = new firebase.auth.GoogleAuthProvider();
   private facebookProvider = new firebase.auth.FacebookAuthProvider();
+  private twitterProvider = new firebase.auth.TwitterAuthProvider();
 
   constructor(private afAuth: AngularFireAuth) {}
 
@@ -21,6 +22,8 @@ export class AuthService {
         return this.afAuth.auth.signInWithPopup(this.googleProvider);
       case 'facebook':
         return this.afAuth.auth.signInWithPopup(this.facebookProvider);
+      case 'twitter':
+        return this.afAuth.auth.signInWithPopup(this.twitterProvider);
       default:
         return Promise.reject(Error('Unknown AuthProvider Passed'));
     }

--- a/src/app/authentication/state/auth.facade.ts
+++ b/src/app/authentication/state/auth.facade.ts
@@ -107,6 +107,10 @@ export class AuthFacade {
     this.store.dispatch(new LoginAction({ provider: 'facebook' }));
   }
 
+  twitterLogin() {
+    this.store.dispatch(new LoginAction({ provider: 'twitter' }));
+  }
+
   logout() {
     this.store.dispatch(new LogoutAction());
   }


### PR DESCRIPTION
- Add Twitter button to the login view for the user to select.
- Add click function to the container to call the service logic to execute.
- Utilized the built-in firebase functionality for twitter authentication.