### PR TITLE
fix(uid): remove uid$ that is causing an error

### DIFF
--- a/src/app/dashboard/container/dashboard/dashboard.component.html
+++ b/src/app/dashboard/container/dashboard/dashboard.component.html
@@ -9,7 +9,6 @@
 </ion-toolbar>
 
 <ion-content>
-  {{ user$ | async | json}}
   <app-join-session (join)="handleJoin($event)"></app-join-session>
 
   <app-connection-list [connections]="connections$ | async" (add)="addConnection()" (select)="createSession($event)"></app-connection-list>

--- a/src/app/dashboard/container/dashboard/dashboard.component.html
+++ b/src/app/dashboard/container/dashboard/dashboard.component.html
@@ -9,11 +9,12 @@
 </ion-toolbar>
 
 <ion-content>
+  {{ user$ | async | json}}
   <app-join-session (join)="handleJoin($event)"></app-join-session>
 
   <app-connection-list [connections]="connections$ | async" (add)="addConnection()" (select)="createSession($event)"></app-connection-list>
 
-  <app-session-history-list [uid]="uid$ | async" [items]="historyItems$ | async" (options)="handleOptionClick($event)" (detail)="handleDetailClick($event)"></app-session-history-list>
+  <app-session-history-list [items]="historyItems$ | async" (options)="handleOptionClick($event)" (detail)="handleDetailClick($event)"></app-session-history-list>
 
   <ion-infinite-scroll #infiniteScroll (ionInfinite)="loadMore(infiniteScroll)">
     <ion-infinite-scroll-content></ion-infinite-scroll-content>

--- a/src/app/dashboard/container/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/container/dashboard/dashboard.component.ts
@@ -8,6 +8,7 @@ import { map, filter, withLatestFrom, take, tap } from 'rxjs/operators';
 
 import { AppFacade } from '@app/state/app.facade';
 import { RouterFacade } from '@app/state/router.facade';
+import { AuthFacade } from '@app/authentication/state/auth.facade';
 import { DashboardFacade } from '@app/dashboard/state/dashboard.facade';
 import { ConnectionFacade } from '@app/connections/state/connection.facade';
 import { SessionUserType } from '@models/user';
@@ -29,7 +30,7 @@ import { SessionDetailModalComponent } from '@app/dashboard/components/session-d
 export class DashboardComponent implements OnInit, OnDestroy {
   private infiniteScroll: InfiniteScroll;
 
-  uid$ = this.appFacade.uid$;
+  user$ = this.authFacade.user$;
   historyItems$ = this.dashboardFacade.historyItems$.pipe(
     tap(items => {
       if (this.infiniteScroll) {
@@ -45,7 +46,8 @@ export class DashboardComponent implements OnInit, OnDestroy {
     private routerFacade: RouterFacade,
     private dashboardFacade: DashboardFacade,
     private popupSvc: PopupService,
-    private connectionFacade: ConnectionFacade
+    private connectionFacade: ConnectionFacade,
+    private authFacade: AuthFacade
   ) {}
 
   ngOnInit() {

--- a/src/app/dashboard/container/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/container/dashboard/dashboard.component.ts
@@ -30,7 +30,6 @@ import { SessionDetailModalComponent } from '@app/dashboard/components/session-d
 export class DashboardComponent implements OnInit, OnDestroy {
   private infiniteScroll: InfiniteScroll;
 
-  user$ = this.authFacade.user$;
   historyItems$ = this.dashboardFacade.historyItems$.pipe(
     tap(items => {
       if (this.infiniteScroll) {

--- a/src/app/dashboard/services/history.service.ts
+++ b/src/app/dashboard/services/history.service.ts
@@ -11,6 +11,7 @@ import { Observable, BehaviorSubject, Subject, of } from 'rxjs';
 import { tap, share, takeUntil, switchMap, map } from 'rxjs/operators';
 
 import { AppFacade } from '@app/state/app.facade';
+import { AuthFacade } from '@app/authentication/state/auth.facade';
 import { ScopingSession } from '@models/scoping-session';
 import { HistoryItem } from '@models/history-item';
 import { Task } from '@models/task';
@@ -44,6 +45,7 @@ export class HistoryService {
 
   constructor(
     private appFacade: AppFacade,
+    private authFacade: AuthFacade,
     private afs: AngularFirestore,
     private http: HttpClient
   ) {}
@@ -51,10 +53,10 @@ export class HistoryService {
   loadHistoryItems() {
     this.refresh.next();
 
-    this.appFacade.uid$
+    this.authFacade.user$
       .pipe(
-        tap(uid => {
-          this.query.field = `participants.${uid}`;
+        tap(user => {
+          this.query.field = `participants.${user.uid}`;
         }),
         switchMap(() => this.getHistoryItems())
       )

--- a/src/app/state/app.facade.ts
+++ b/src/app/state/app.facade.ts
@@ -13,11 +13,6 @@ export class AppFacade {
 
   authRedirect$ = this.store.pipe(select(AppQuery.selectAuthRedirect));
 
-  uid$ = this.store.pipe(
-    select(AppQuery.selectUid),
-    filter(exists => !!exists)
-  );
-
   uidDocPath$ = this.store.pipe(
     select(AppQuery.selectUidDocPath),
     filter(exists => !!exists)

--- a/src/app/state/app.reducer.ts
+++ b/src/app/state/app.reducer.ts
@@ -50,11 +50,6 @@ export const initialState: AppState = {
 };
 
 export namespace AppQuery {
-  export const selectUid = createSelector(
-    AuthQuery.selectUser,
-    user => user.uid
-  );
-
   export const selectAuthRedirect = createSelector(
     AuthQuery.selectUiState,
     RouterQuery.getQueryParams,


### PR DESCRIPTION
uid$ was causing issues on logout since PR #15. 

It resulted in 6+ errors when a user logs out of the application. This removes uid$ from app.facade and app.reducer.
The only other additional place that it was used was in history.service in which it was replaced by the authFacade.user in which contains the UID needed for that logic.