### PR TITLE
feat(auth): add native google login

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -82,5 +82,8 @@
     <plugin name="cordova-plugin-ionic-webview" spec="1.1.19" />
     <plugin name="cordova-plugin-ionic-keyboard" spec="2.0.5" />
     <engine name="android" />
-    <engine name="ios" />
+    <plugin name="cordova-plugin-googleplus" spec="^5.3.0">
+        <variable name="REVERSE_CLIENT_ID" value="com.googleusercontent.apps.494457695327-611er42ptb000gevad2g51vvcflkif5m" />
+    </plugin>
+    <engine name="ios" spec="4.5.5" />
 </widget>

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@angular/platform-browser-dynamic": "5.2.11",
     "@angular/router": "6.0.7",
     "@ionic-native/core": "4.8.0",
+    "@ionic-native/google-plus": "^4.11.0",
     "@ionic-native/splash-screen": "4.8.0",
     "@ionic-native/status-bar": "4.8.0",
     "@ionic/storage": "2.1.3",
@@ -44,8 +45,9 @@
     "@ngrx/store": "6.0.0-beta.1",
     "@ngrx/store-devtools": "6.0.0-beta.1",
     "angularfire2": "5.0.0-rc.4",
-    "core-js": "2.5.3",
     "cordova-ios": "4.5.5",
+    "cordova-plugin-googleplus": "^5.3.0",
+    "core-js": "2.5.3",
     "firebase": "4.12.1",
     "functions": "file:functions",
     "ionic-angular": "3.9.2",
@@ -111,6 +113,11 @@
     "platforms": [
       "android",
       "ios"
-    ]
+    ],
+    "plugins": {
+      "cordova-plugin-googleplus": {
+        "REVERSE_CLIENT_ID": "com.googleusercontent.apps.494457695327-611er42ptb000gevad2g51vvcflkif5m"
+      }
+    }
   }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -42,6 +42,7 @@ import { AppRoutingModule } from "./app-routing.module";
 import { ConnectionsModule } from "../features/connections/connections.module";
 import { ScopingService } from "../features/scoping/services/scoping.service";
 import { ScopingFacade } from "../features/scoping/store/scoping.facade";
+import { GooglePlus } from "../../node_modules/@ionic-native/google-plus";
 
 @NgModule({
   declarations: [JuntoScopeComponent, NotFoundComponent],
@@ -70,6 +71,7 @@ import { ScopingFacade } from "../features/scoping/store/scoping.facade";
     AuthGuard,
     StatusBar,
     SplashScreen,
+    GooglePlus,
     PopupService,
     ScopingService,
     ScopingFacade,


### PR DESCRIPTION
After reading [this](https://angularfirebase.com/lessons/ionic-google-login-with-firebase-and-angularfire/) i add the native google login into the app after add both apps into the firebase console.

I left the web login so we can still login with google in the browser and app. Also i fix the issue with redirecting after login, this problem is that while the native popup for google login show up, we redirects to dashboard (we are not waiting until we have the user logged in), now i'm waiting until we have the user to redirects for both (web and native).