### PR TITLE
fix(): fix ticket 81

### DIFF
--- a/functions/src/api/connections/projects/sessions/add-session.ts
+++ b/functions/src/api/connections/projects/sessions/add-session.ts
@@ -1,33 +1,33 @@
-import * as express from 'express';
+import * as express from "express";
 
-import * as _ from 'lodash';
+import * as _ from "lodash";
 
 import {
   firestore,
   encryptionService,
   sessionService,
-  teamworkService,
-} from './../../../../services';
+  teamworkService
+} from "./../../../../services";
 
 export async function addSession(req: express.Request, res: express.Response) {
   const uid = res.locals.user.uid;
   const { connectionId, projectId } = req.params;
-  const { taskListIds } = req.body;
+  const { taskListIds, projectName } = req.body;
 
   if (!connectionId) {
     return res
       .status(400)
-      .json({ message: 'Connection id is a required parameter.' });
+      .json({ message: "Connection id is a required parameter." });
   }
 
   if (!projectId) {
     return res
       .status(400)
-      .json({ message: 'Project id is a required parameter.' });
+      .json({ message: "Project id is a required parameter." });
   }
 
   if (!Array.isArray(taskListIds) || taskListIds.length === 0) {
-    return res.status(400).json({ message: 'Task List Ids is required' });
+    return res.status(400).json({ message: "Task List Ids is required" });
   }
 
   const connection = await firestore
@@ -36,14 +36,14 @@ export async function addSession(req: express.Request, res: express.Response) {
     .then(snapshot => snapshot.data());
 
   if (!connection) {
-    return res.status(400).json({ message: 'Invalid connection id.' });
+    return res.status(400).json({ message: "Invalid connection id." });
   }
 
   let sessionTasks;
   let newSession;
   try {
     switch (connection.type) {
-      case 'teamwork': {
+      case "teamwork": {
         const token = encryptionService.decrypt(connection.token);
         const baseUrl = connection.externalData.baseUrl;
 
@@ -66,7 +66,7 @@ export async function addSession(req: express.Request, res: express.Response) {
       }
 
       default: {
-        return res.status(400).json({ message: 'Unknown Connection Type' });
+        return res.status(400).json({ message: "Unknown Connection Type" });
       }
     }
 
@@ -74,7 +74,8 @@ export async function addSession(req: express.Request, res: express.Response) {
       uid,
       connectionId,
       projectId,
-      sessionTasks
+      sessionTasks,
+      projectName
     );
   } catch (error) {
     return res.status(400).json({ message: error });

--- a/functions/src/services/session.service.ts
+++ b/functions/src/services/session.service.ts
@@ -13,7 +13,13 @@ export class SessionService {
 
   constructor(private firestore: Firestore) {}
 
-  async createSession(ownerId, connectionId, projectId, sessionTasks) {
+  async createSession(
+    ownerId,
+    connectionId,
+    projectId,
+    sessionTasks,
+    projectName
+  ) {
     const { accessCode, expirationDate } = this.generateAccessCode();
 
     const sessionDocRef = this.firestore
@@ -65,6 +71,7 @@ export class SessionService {
             ownerId,
             connectionId,
             projectId,
+            projectName,
             sessionId: sessionDocRef.id,
             participants: { [ownerId]: Date.now() }
           });

--- a/src/features/connections/pages/select-task-list/select-task-list.component.ts
+++ b/src/features/connections/pages/select-task-list/select-task-list.component.ts
@@ -60,7 +60,8 @@ export class SelectTaskListComponent implements OnInit {
     this.connectionFacade.createSession(
       this.connectionId,
       this.projectId,
-      this.taskListIds
+      this.taskListIds,
+      this.projectName
     );
   }
 }

--- a/src/features/connections/services/connection.service.ts
+++ b/src/features/connections/services/connection.service.ts
@@ -71,13 +71,14 @@ export class ConnectionService {
   createSession(
     connectionId: string,
     projectId: string,
-    taskListIds: string[]
+    taskListIds: string[],
+    projectName: string
   ) {
     return this.http.post<{ sessionCode: string; accessCode: string }>(
       `${
         environment.apiBaseUrl
       }/connections/${connectionId}/projects/${projectId}/sessions`,
-      { taskListIds }
+      { taskListIds, projectName }
     );
   }
 }

--- a/src/features/connections/store/connection.actions.ts
+++ b/src/features/connections/store/connection.actions.ts
@@ -84,6 +84,7 @@ export class CreateSessionAction implements Action {
       connectionId: string;
       projectId: string;
       taskListIds: string[];
+      projectName: string;
     }
   ) {}
 }

--- a/src/features/connections/store/connection.facade.ts
+++ b/src/features/connections/store/connection.facade.ts
@@ -180,7 +180,8 @@ export class ConnectionFacade {
         .createSession(
           action.payload.connectionId,
           action.payload.projectId,
-          action.payload.taskListIds
+          action.payload.taskListIds,
+          action.payload.projectName
         )
         .pipe(
           tap(response => {
@@ -293,10 +294,16 @@ export class ConnectionFacade {
   createSession(
     connectionId: string,
     projectId: string,
-    taskListIds: string[]
+    taskListIds: string[],
+    projectName: string
   ) {
     this.store.dispatch(
-      new CreateSessionAction({ connectionId, projectId, taskListIds })
+      new CreateSessionAction({
+        connectionId,
+        projectId,
+        taskListIds,
+        projectName
+      })
     );
   }
 }

--- a/src/features/dashboard/components/session-history-item/session-history-item.component.html
+++ b/src/features/dashboard/components/session-history-item/session-history-item.component.html
@@ -3,8 +3,7 @@
     <ion-grid>
       <ion-row>
         <ion-col col-6>
-          <!-- TODO : the h2 should have the project name -->
-          <h2>{{ item.projectId }}</h2>          
+          <h2>{{ item.projectName }}</h2>          
         </ion-col>
         <ion-col col-6>
           <button ion-fab mini item-end>{{ abbreviation }}</button>


### PR DESCRIPTION
This PR the fix for the ticket #81, adds the project name in to the session details so on dashboard we can display the name.

**But**, the only thing to keep in mind is that the previous sessions already created probably wont have this attribute so will display in blank but this is for the old sessions, the new ones will be created with the project name (this name is sent from the client app).

Also this only will works on local until we deploy the functions on firebase.