### PR TITLE
CleanErrorAction Adjustment

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -95,6 +95,7 @@
         <variable name="APP_ID" value="1427549454016328" />
         <variable name="APP_NAME" value="“JuntoScope”" />
         <variable name="ANDROID_SDK_VERSION" value="4.+" />
+    </plugin>
     <plugin name="twitter-connect-plugin" spec="https://github.com/chroa/twitter-connect-plugin">
         <variable name="FABRIC_KEY" value="1ba0dc025725ca34727a6f26e9be759d120e4bad" />
         <variable name="TWITTER_KEY" value="RpWT5YZYdFYjPSzI8wB5O4kwP" />

--- a/src/features/authentication/store/auth.facade.ts
+++ b/src/features/authentication/store/auth.facade.ts
@@ -22,7 +22,8 @@ import {
   NotAuthenticatedAction,
   AuthenticatedAction,
   LoginAction,
-  LogoutAction
+  LogoutAction,
+  ClearErrorAction
 } from "./auth.actions";
 import { AuthService } from "../services/auth.service";
 import { HistoryService } from "../../dashboard/services/history.service";
@@ -116,5 +117,9 @@ export class AuthFacade {
   logout() {
     this.historySvc.logOut(); // Unsubscribes from uid
     this.store.dispatch(new LogoutAction());
+  }
+
+  clearError() {
+    this.store.dispatch(new ClearErrorAction());
   }
 }

--- a/src/features/connections/pages/add-connection/add-connection.component.ts
+++ b/src/features/connections/pages/add-connection/add-connection.component.ts
@@ -9,12 +9,10 @@ import {
 
 import { Actions } from "@ngrx/effects";
 import { Subscription } from "rxjs";
-import { Store } from "@ngrx/store";
 
-import { ConnectionActionTypes, ClearErrorAction } from "../../store/connection.actions";
+import { ConnectionActionTypes } from "../../store/connection.actions";
 import { PopupService } from "../../../../shared/popup.service";
 import { ConnectionFacade } from "../../store/connection.facade";
-import { AppState } from "../../../../store/app.reducer";
 import { LoadingService } from "../../../../shared/loading.service";
 
 
@@ -29,18 +27,15 @@ import { LoadingService } from "../../../../shared/loading.service";
 export class AddConnectionPage implements OnInit {
   connectionForm: FormGroup;
   type: string;
-
+  errorSubscription: Subscription;
+  redirectSubs: Subscription;
   addError$ = this.connectionFacade.error$;
 
-  redirectSubs: Subscription;
-
   constructor(
-    private store: Store<AppState>,
     private fb: FormBuilder,
     private navCtrl: NavController,
     private connectionFacade: ConnectionFacade,
     private actions$: Actions,
-    private loadingCtrl: LoadingController,
     private popupSvc: PopupService,
     private loadingSvc: LoadingService
   ) {
@@ -52,11 +47,11 @@ export class AddConnectionPage implements OnInit {
         this.navCtrl.push("DashboardPage");
       });
 
-    this.addError$.subscribe(error => {
+    this.errorSubscription = this.addError$.subscribe(error => {
       if (error) {
         this.loadingSvc.hide();
         this.popupSvc.simpleAlert("Uh Oh!", error, "OK");
-        this.store.dispatch(new ClearErrorAction());
+        this.connectionFacade.clearError();
       }
     });
   }
@@ -64,6 +59,10 @@ export class AddConnectionPage implements OnInit {
   ngOnInit() {
     this.createForm();
     this.loadingSvc.initialize();
+  }
+
+  ngOnDestroy() {
+    this.errorSubscription.unsubscribe();
   }
 
   setType(type: string) {

--- a/src/features/connections/store/connection.facade.ts
+++ b/src/features/connections/store/connection.facade.ts
@@ -26,7 +26,8 @@ import {
   AddConnectionErrorAction,
   NoConnectionsAction,
   CreateSessionAction,
-  AddConnectionSuccessAction
+  AddConnectionSuccessAction,
+  ClearErrorAction
 } from "./connection.actions";
 import { ConnectionService } from "../services/connection.service";
 import { Connection } from "../../../models/connection";
@@ -297,5 +298,9 @@ export class ConnectionFacade {
         projectName
       })
     );
+  }
+
+  clearError() {
+    this.store.dispatch(new ClearErrorAction());
   }
 }

--- a/src/features/dashboard/store/dashboard.facade.ts
+++ b/src/features/dashboard/store/dashboard.facade.ts
@@ -26,7 +26,8 @@ import {
   DeleteSessionAction,
   DeleteSessionErrorAction,
   RefreshAccessCodeAction,
-  RefreshAccessCodeErrorAction
+  RefreshAccessCodeErrorAction,
+  ClearErrorAction
 } from "./dashboard.actions";
 import { HistoryService } from "../services/history.service";
 import { HistoryItem } from "../../../models/history-item";
@@ -146,6 +147,11 @@ export class DashboardFacade {
   getMoreHistory() {
     this.store.dispatch(new LoadMoreHistoryItemsAction());
   }
+  
+  clearError() {
+    this.store.dispatch(new ClearErrorAction());
+  }
+
 }
 
 const itemFromChangeAction = (

--- a/src/features/scoping/components/session-access/session-access.component.ts
+++ b/src/features/scoping/components/session-access/session-access.component.ts
@@ -35,7 +35,7 @@ export class SessionAccessComponent implements OnInit, OnDestroy {
     this.errorSubscription = this.error$.subscribe(error => {
       if (error) {
         this.popupSvc.simpleAlert("Uh Oh!", error, "OK");
-        this.scopingFacade.ClearErrorAction();
+        this.scopingFacade.clearError();
       }
     });
   }

--- a/src/features/scoping/store/scoping.facade.ts
+++ b/src/features/scoping/store/scoping.facade.ts
@@ -234,7 +234,7 @@ export class ScopingFacade {
     );
   }
 
-  ClearErrorAction() {
+  clearError() {
     this.store.dispatch(new ClearErrorAction());
   }
 }


### PR DESCRIPTION
I adjusted all the CleanErrorAction logic in other features that way we are consistent with this logic and how we are utilizing this when errors are generated.
I based my adjustments off of #118 where Fernando was able to resolve the issue with the error state not completely being destroyed.

In addition, I noticed an issue with a closing tag being removed from the config.xml when I was preparing my platform(s) to build to devices. I added this adjustment in as well.